### PR TITLE
Improve mobile readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+# Webstorm
+.idea

--- a/src/layouts/RetroLayout.astro
+++ b/src/layouts/RetroLayout.astro
@@ -253,4 +253,15 @@ import CookieBanner from "../components/CookieBanner.astro";
   [data-ai-support-amount="low"] [data-tooltip]:after {
     content: "Supporto limitato: revisione di alcune frasi e paragrafi.";
   }
+
+  /* MOBILE ONLY */
+  @media (max-width: 600px) {
+    main {
+        max-width: 100%;
+        font-size: 14px;
+    }
+    h2 {
+        font-size: 1.2em;
+    }
+  }
 </style>


### PR DESCRIPTION
- Fix font size for mobile version
- Add `.idea` folder to `.gitignore` in order to work with Webstorm as well
<img width="997" alt="Fix 1" src="https://github.com/Cadienvan/Cadienvan.github.io/assets/8136137/1c1119b8-a334-4d1b-82c5-46d0593994a9">
<img width="998" alt="Fix 2" src="https://github.com/Cadienvan/Cadienvan.github.io/assets/8136137/cfe32b76-c983-4bfb-ba01-84746ed0cf21">
