### PR TITLE
feat: new blog post — C'è un tempo e un luogo per ogni cosa, ma non adesso

### DIFF
--- a/src/pages/blog/en/theres-a-time-and-a-place.md
+++ b/src/pages/blog/en/theres-a-time-and-a-place.md
@@ -7,6 +7,7 @@ date: 2026-04-17
 AISupport: mid
 lang: en
 hasTranslation: true
+customTranslationUrl: /blog/tempo-e-luogo-per-ogni-cosa
 ---
 
 I'm in my thirties and I still have my Game Boy Color on the shelf. I turn it on sometimes, especially when I need to remind myself that simplicity works. And every time I do, I stumble into one of the most important lessons in software engineering — disguised as dialogue from a children's video game.
@@ -49,7 +50,7 @@ Scaling a problem that doesn't exist is one of the most effective ways to create
 
 In Pokémon terms: it's like teaching *Hydro Pump* to a level 3 Magikarp. The move exists, it's powerful, it makes sense — just not for that Pokémon, not at that moment. You have to wait until level 20 first. You have to earn your Gyarados.
 
-❌ **The trap**: "When we scale, we'll already be ready."
+❌ **The trap**: "When we scale, we'll already be ready."  
 ✅ **Reality**: When you scale, you'll know what to build. Right now, you don't.
 
 ### 2. Microservices for a Team of One
@@ -64,7 +65,7 @@ The result? A distributed monolith. That is: all the disadvantages of microservi
 
 It's the equivalent of teaching your Pokémon only moves of a different type, hoping it "covers more ground." In theory it makes sense. In practice, it'll never be super effective at anything, and it loses all the STAB bonuses — the Same Type Attack Bonus you get when you use a move that matches your Pokémon's type.
 
-❌ **The trap**: "It's best practice."
+❌ **The trap**: "It's best practice."  
 ✅ **Reality**: It's best practice *in a specific context*. Your context is different.
 
 ### 3. AI Solving Problems You Don't Have
@@ -124,4 +125,3 @@ The technologies you adopt prematurely aren't wrong in the abstract. Often they'
 And meanwhile, the problem you do have — the real one, the one your users are waiting for you to solve — is sitting there, waiting.
 
 **It's not the time to use the bike. Go on foot. It's faster.**
-

--- a/src/pages/blog/en/theres-a-time-and-a-place.md
+++ b/src/pages/blog/en/theres-a-time-and-a-place.md
@@ -125,10 +125,3 @@ And meanwhile, the problem you do have — the real one, the one your users are 
 
 **It's not the time to use the bike. Go on foot. It's faster.**
 
----
-
-*Over to you: have you lived through situations where a solution that was "too advanced" blocked you instead of accelerating things? Tell me about it.*
-
----
-
-*P.S. This article was written with AI support. Professor Oak and my Game Boy Color, on the other hand, are entirely mine.*

--- a/src/pages/blog/en/theres-a-time-and-a-place.md
+++ b/src/pages/blog/en/theres-a-time-and-a-place.md
@@ -1,0 +1,134 @@
+---
+layout: ../../../layouts/_partials/RetroBlogPostLayout.astro
+title: "There's a Time and a Place for Everything, but Not Now"
+author: Michael Di Prisco
+description: As Professor Oak teaches us, some solutions must be used in the right place, at the right time. Doing today what isn't needed yet — in architecture, leadership, or AI — can destroy a team.
+date: 2026-04-17
+AISupport: mid
+lang: en
+hasTranslation: true
+---
+
+I'm in my thirties and I still have my Game Boy Color on the shelf. I turn it on sometimes, especially when I need to remind myself that simplicity works. And every time I do, I stumble into one of the most important lessons in software engineering — disguised as dialogue from a children's video game.
+
+In the world of Pokémon, when you try to ride your bicycle inside a building, the game stops you and tells you: *"There's a time and a place for everything, but not now."*
+
+I've thought about that line a lot. More than I probably should, honestly.
+
+Because in our industry, we do exactly the opposite. We bring the bicycle inside. We adopt tomorrow's solution to solve today's problem. And then we wonder why the team is stuck, the software is rigid, and nobody wants to touch that service that "works but nobody knows how."
+
+**The problem isn't the solution. The problem is the timing.**
+
+---
+
+## The Future Trap
+
+There's a subtle bias that hits the best teams: the idea that preparing architecture for the future is always a good idea. That being *forward-thinking* means building today what you'll need in three years.
+
+It's not.
+
+Building for a future that doesn't exist yet isn't foresight. It's speculation. And it's one of the most subtle forms of *over-engineering* there is, because it disguises itself as responsibility.
+
+Think of it like training your Pokémon team: you don't attempt the Elite Four with a level 5 Pikachu, even if it's "theoretically" one of the most iconic Pokémon in the franchise. You need the right moment, the right context, the right level.
+
+The right question isn't *"will this solution be useful someday?"*. The right question is: **"is this solution useful right now, for the problem I have right now?"**
+
+---
+
+## Three Examples I've Seen First-Hand
+
+### 1. OLAP on 10 MB of Data
+
+Picture a team of three people. A database with less than 10 MB of data. An application running simple queries on a handful of tables.
+
+*"We should move to an OLAP architecture and build a Data Lake. It scales better."*
+
+Scales what, exactly?
+
+Scaling a problem that doesn't exist is one of the most effective ways to create a new one. A relational database with a few well-placed indexes would have solved everything in an afternoon. Instead, weeks are spent configuring tools designed for petabytes of data, while the real problem — the one the client is waiting for — sits in the queue.
+
+In Pokémon terms: it's like teaching *Hydro Pump* to a level 3 Magikarp. The move exists, it's powerful, it makes sense — just not for that Pokémon, not at that moment. You have to wait until level 20 first. You have to earn your Gyarados.
+
+❌ **The trap**: "When we scale, we'll already be ready."
+✅ **Reality**: When you scale, you'll know what to build. Right now, you don't.
+
+### 2. Microservices for a Team of One
+
+One project, one team, no need for separate deployments. Everything runs smoothly.
+
+*"Let's do microservices. It's the standard."*
+
+Microservices solve a specific problem: the need to scale teams, separate bounded contexts, deploy independently. If you don't have that problem, you've just imported dozens of new ones — network latency, service discovery, distributed tracing, failure handling — in exchange for zero concrete benefits.
+
+The result? A distributed monolith. That is: all the disadvantages of microservices, none of the advantages.
+
+It's the equivalent of teaching your Pokémon only moves of a different type, hoping it "covers more ground." In theory it makes sense. In practice, it'll never be super effective at anything, and it loses all the STAB bonuses — the Same Type Attack Bonus you get when you use a move that matches your Pokémon's type.
+
+❌ **The trap**: "It's best practice."
+✅ **Reality**: It's best practice *in a specific context*. Your context is different.
+
+### 3. AI Solving Problems You Don't Have
+
+Worth mentioning: introducing a generative AI layer into a workflow where the bottleneck is human, not computational, is the architectural equivalent of bringing your bike into an underwater dungeon.
+
+AI is a powerful tool. Like all powerful tools, it amplifies. If the problem is real, it amplifies the solution. If the problem isn't real, it amplifies the chaos.
+
+In Pokémon too, an HM — Hidden Machine — can only be used in certain parts of the map. *Surf* gets you across the ocean. Using it in a grassy field takes you nowhere. It's not a flaw in the move. It's a flaw in the context in which you're using it.
+
+---
+
+## The Question Nobody Asks
+
+Before adopting a new technology, a new pattern, a new framework, there's a simple question almost no team systematically asks itself:
+
+**"What specific problem, that we have *today*, does this thing solve?"**
+
+Not tomorrow. Not "when we scale." Today.
+
+If the answer is vague, or starts with "well, in the future we could...", stop. It's not the time. It's not the place.
+
+This doesn't mean being conservative. It means being honest with yourself and your context. It means recognizing that **architectural decisions have a cost**, and that cost is paid immediately — even if the benefits arrive, maybe, years from now.
+
+---
+
+## The Difference Between Vision and Escape
+
+There's a subtle but crucial distinction between having vision and using the future as an excuse not to do the hard things now.
+
+Vision says: *"Let's build the simplest thing that works. When the problem changes, we'll change too."*
+
+Escape says: *"Let's build the most complex thing, so we don't have to face the real problem."*
+
+I've seen both. The second one has one unmistakable signal: nobody knows exactly what problem is being solved, but everyone agrees the solution is very elegant.
+
+Professor Oak didn't give you a Pokédex full of already-caught Pokémon. He didn't hand you the Master Ball on day one. He said: *"Go. Explore. Learn."* Every tool in its right moment, every badge earned in the field — not gifted.
+
+---
+
+## What to Do Instead
+
+✅ **Tip**: Before adopting any "enterprise" or "scalable" solution, ask yourself — how many requests per second are we handling today? How many people use this system? What's the cost of getting this decision wrong in six months?
+
+✅ **Tip**: Distinguish between *reversible* and *irreversible* decisions. The former can be made quickly and corrected just as quickly. The latter deserve more time, more context, more humility.
+
+✅ **Tip**: Normalize "not yet" as a legitimate technical answer. It's not laziness. It's priority.
+
+---
+
+## Professor Oak Was Right
+
+The bicycle works. It's a useful tool. But riding it inside a building isn't a problem with the bicycle — it's a problem of context.
+
+The technologies you adopt prematurely aren't wrong in the abstract. Often they're excellent. The problem is that you're using them in the wrong place, at the wrong time, for a problem you don't have yet.
+
+And meanwhile, the problem you do have — the real one, the one your users are waiting for you to solve — is sitting there, waiting.
+
+**It's not the time to use the bike. Go on foot. It's faster.**
+
+---
+
+*Over to you: have you lived through situations where a solution that was "too advanced" blocked you instead of accelerating things? Tell me about it.*
+
+---
+
+*P.S. This article was written with AI support. Professor Oak and my Game Boy Color, on the other hand, are entirely mine.*

--- a/src/pages/blog/tempo-e-luogo-per-ogni-cosa.md
+++ b/src/pages/blog/tempo-e-luogo-per-ogni-cosa.md
@@ -1,0 +1,134 @@
+---
+layout: ../../layouts/_partials/RetroBlogPostLayout.astro
+title: "C'è un tempo e un luogo per ogni cosa, ma non adesso"
+author: Michael Di Prisco
+description: Come il Professor Oak insegna, alcune soluzioni vanno usate nel posto giusto, al momento giusto. Fare oggi ciò che non è ancora necessario — in architettura, leadership o AI — può distruggere un team.
+date: 2026-04-17
+AISupport: mid
+lang: it
+hasTranslation: true
+---
+
+Ho più di trent'anni e ho ancora il Gameboy Color sullo scaffale. Lo accendo ogni tanto, soprattutto quando ho bisogno di ricordarmi che la semplicità funziona. E ogni volta che lo faccio, mi imbatto in una delle lezioni più importanti dell'ingegneria del software — camuffata da dialogo di un videogioco per bambini.
+
+Nel mondo di Pokémon, quando provi a usare la bicicletta dentro un edificio, il gioco ti ferma e ti dice: *"C'è un tempo e un luogo per ogni cosa, ma non adesso."*
+
+Ho pensato a quella frase molte volte. Più di quanto dovrei, onestamente.
+
+Perché nella nostra industria si fa esattamente il contrario. Si porta la bicicletta dentro. Si adotta la soluzione di domani per risolvere il problema di oggi. E poi ci si chiede perché il team è in stallo, il software è ingessato, e nessuno vuole toccare quel servizio "che funziona ma non si sa bene come."
+
+**Il problema non è la soluzione. Il problema è il tempismo.**
+
+---
+
+## La trappola del futuro
+
+C'è un bias sottile che colpisce i team migliori: l'idea che preparare l'architettura per il futuro sia sempre una buona idea. Che essere *forward-thinking* significhi costruire oggi ciò di cui avrai bisogno tra tre anni.
+
+Non è così.
+
+Costruire per un futuro che non esiste ancora non è lungimiranza. È speculazione. Ed è una delle forme più sottili di *over-engineering* che esistano, perché si maschera da responsabilità.
+
+Pensaci come se stessi allenando il tuo team di Pokémon: non si affrontano i Quattro Draghi con un Pikachu al livello 5, anche se "in potenza" è uno dei Pokémon più iconici del franchise. Serve il momento giusto, il contesto giusto, il livello giusto.
+
+La domanda giusta non è *"questa soluzione sarà utile un giorno?"*. La domanda giusta è: **"questa soluzione è utile adesso, per il problema che ho adesso?"**
+
+---
+
+## Tre esempi che ho visto con i miei occhi
+
+### 1. OLAP su 10 MB di dati
+
+Immagina un team di tre persone. Un database con meno di 10 MB di dati. Un'applicazione che fa query semplici su poche tabelle.
+
+*"Dovremmo passare a un'architettura OLAP e costruire un Data Lake. Scala meglio."*
+
+Scala cosa, esattamente?
+
+Scalare un problema che non esiste è uno dei modi più efficaci per crearne uno nuovo. Un database relazionale con qualche indice fatto bene avrebbe risolto tutto in un pomeriggio. Invece si passano settimane a configurare strumenti progettati per petabyte di dati, mentre il problema reale — quello che il cliente aspetta — rimane in coda.
+
+Nel linguaggio Pokémon: è come insegnare *Idro Pompa* a un Magikarp al livello 3. La mossa esiste, è potente, ha senso — ma non per quel Pokémon, non in quel momento. Prima devi aspettare il livello 20. Prima devi guadagnarti Gyarados.
+
+❌ **La trappola**: "Quando cresceremo, saremo già pronti."
+✅ **La realtà**: Quando crescerete, saprete cosa costruire. Adesso non lo sapete ancora.
+
+### 2. Microservizi per un team da uno
+
+Un progetto, un team, nessuna necessità di deploy separati. Tutto fila.
+
+*"Facciamo microservizi. È lo standard."*
+
+I microservizi risolvono un problema specifico: la necessità di scalare il team, separare i bounded context, deployare in modo indipendente. Se non hai quel problema, hai appena importato decine di problemi nuovi — latenza di rete, *service discovery*, *distributed tracing*, gestione dei fallimenti — in cambio di zero benefici concreti.
+
+Il risultato? Un monolite distribuito. Ovvero: tutti gli svantaggi dei microservizi, nessuno dei vantaggi.
+
+È l'equivalente di insegnare al tuo Pokémon solo mosse di tipo diverso dal suo, sperando che "copra più terreno." In teoria ha senso. In pratica, non sarà mai super efficace su nulla, e perderà tutti i bonus del STAB — il Same Type Attack Bonus che ottieni quando usi una mossa dello stesso tipo del tuo Pokémon.
+
+❌ **La trappola**: "È best practice."
+✅ **La realtà**: È best practice *in un contesto specifico*. Il tuo contesto è diverso.
+
+### 3. L'AI che risolve problemi che non hai
+
+Vale la pena citarla: introdurre un layer di AI generativa in un workflow dove il collo di bottiglia è umano, non computazionale, è l'equivalente architetturale di portare la bici in un dungeon sottomarino.
+
+L'AI è uno strumento potente. Come tutti gli strumenti potenti, amplifica. Se il problema è reale, amplifica la soluzione. Se il problema non è reale, amplifica il caos.
+
+Anche in Pokémon, una MN — le Mosse Nascoste — può essere usata solo in certi punti della mappa. *Surf* ti serve per attraversare l'oceano. Usarla in un campo erboso non ti porta da nessuna parte. Non è un difetto della mossa. È un difetto del contesto in cui la stai usando.
+
+---
+
+## La domanda che nessuno fa
+
+Prima di adottare una nuova tecnologia, un nuovo pattern, un nuovo framework, c'è una domanda semplice che quasi nessun team si fa sistematicamente:
+
+**"Quale problema specifico, che abbiamo *oggi*, questa cosa risolve?"**
+
+Non domani. Non "quando scaleremo." Oggi.
+
+Se la risposta è vaga, o inizia con "beh, in futuro potremmo...", fermati. Non è il momento. Non è il luogo.
+
+Questo non significa essere conservatori. Significa essere onesti con sé stessi e con il proprio contesto. Significa riconoscere che **le decisioni architetturali hanno un costo**, e quel costo va pagato subito — anche se i benefici arrivano, forse, tra anni.
+
+---
+
+## La differenza tra visione e fuga
+
+C'è una distinzione sottile, ma cruciale, tra avere visione e usare il futuro come scusa per non fare le cose difficili adesso.
+
+La visione dice: *"Costruiamo la cosa più semplice che funziona. Quando il problema cambierà, cambieremo anche noi."*
+
+La fuga dice: *"Costruiamo la cosa più complessa, così non dobbiamo affrontare il problema reale."*
+
+Ho visto entrambe. La seconda si riconosce da un segnale infallibile: nessuno sa esattamente qual è il problema che si sta risolvendo, ma tutti concordano che la soluzione è molto elegante.
+
+Il Professor Oak non ti dava la Pokédex già piena di Pokémon catturati. Non ti consegnava la Master Ball al primo giorno di gioco. Ti diceva: *"Vai, esplora, impara."* Ogni strumento al momento giusto, ogni badge conquistato sul campo — non regalato.
+
+---
+
+## Cosa fare invece
+
+✅ **Consiglio**: Prima di adottare qualsiasi soluzione "enterprise" o "scalabile", chiediti — quante richieste al secondo gestiamo oggi? Quante persone usano questo sistema? Qual è il costo di sbagliare questa decisione tra sei mesi?
+
+✅ **Consiglio**: Distingui tra *decisioni reversibili* e *decisioni irreversibili*. Le prime si prendono velocemente e si correggono altrettanto velocemente. Le seconde meritano più tempo, più contesto, più umiltà.
+
+✅ **Consiglio**: Normalizza il "non ancora" come risposta tecnica legittima. Non è pigrizia. È priorità.
+
+---
+
+## Il Professor Oak aveva ragione
+
+La bici funziona. È uno strumento utile. Ma usarla dentro un edificio non è un problema della bici — è un problema di contesto.
+
+Le tecnologie che adotti prematuramente non sono sbagliate in assoluto. Spesso sono ottime. Il problema è che le stai usando nel posto sbagliato, al momento sbagliato, per un problema che non hai ancora.
+
+E nel frattempo, il problema che hai — quello vero, quello che i tuoi utenti aspettano che tu risolva — rimane lì, ad aspettare.
+
+**Non è il momento di usare la bici. Vai a piedi. Ci vuole meno.**
+
+---
+
+*A te la palla: hai vissuto situazioni in cui una soluzione "troppo avanti" ha bloccato invece di accelerare? Raccontamelo.*
+
+---
+
+*P.S. Questo articolo è stato scritto con il supporto di AI. Il Professor Oak e il mio Gameboy Color, invece, sono tutti miei.*

--- a/src/pages/blog/tempo-e-luogo-per-ogni-cosa.md
+++ b/src/pages/blog/tempo-e-luogo-per-ogni-cosa.md
@@ -1,17 +1,18 @@
 ---
 layout: ../../layouts/_partials/RetroBlogPostLayout.astro
-title: "C'è un tempo e un luogo per ogni cosa, ma non adesso"
+title: "C'è un tempo e un luogo per ogni cosa, ma non ora"
 author: Michael Di Prisco
 description: Come il Professor Oak insegna, alcune soluzioni vanno usate nel posto giusto, al momento giusto. Fare oggi ciò che non è ancora necessario — in architettura, leadership o AI — può distruggere un team.
 date: 2026-04-17
 AISupport: mid
 lang: it
 hasTranslation: true
+customTranslationUrl: /blog/en/theres-a-time-and-a-place
 ---
 
 Ho più di trent'anni e ho ancora il Gameboy Color sullo scaffale. Lo accendo ogni tanto, soprattutto quando ho bisogno di ricordarmi che la semplicità funziona. E ogni volta che lo faccio, mi imbatto in una delle lezioni più importanti dell'ingegneria del software — camuffata da dialogo di un videogioco per bambini.
 
-Nel mondo di Pokémon, quando provi a usare la bicicletta dentro un edificio, il gioco ti ferma e ti dice: *"C'è un tempo e un luogo per ogni cosa, ma non adesso."*
+Nel mondo di Pokémon, quando provi a usare la bicicletta dentro un edificio, il gioco ti ferma e ti dice: *"C'è un tempo e un luogo per ogni cosa, ma non ora."*
 
 Ho pensato a quella frase molte volte. Più di quanto dovrei, onestamente.
 
@@ -29,7 +30,7 @@ Non è così.
 
 Costruire per un futuro che non esiste ancora non è lungimiranza. È speculazione. Ed è una delle forme più sottili di *over-engineering* che esistano, perché si maschera da responsabilità.
 
-Pensaci come se stessi allenando il tuo team di Pokémon: non si affrontano i Quattro Draghi con un Pikachu al livello 5, anche se "in potenza" è uno dei Pokémon più iconici del franchise. Serve il momento giusto, il contesto giusto, il livello giusto.
+Pensaci come se stessi allenando il tuo team di Pokémon: non si affrontano i Superquattro con un Pikachu al livello 5, anche se "in potenza" è uno dei Pokémon più iconici del franchise. Serve il momento giusto, il contesto giusto, il livello giusto.
 
 La domanda giusta non è *"questa soluzione sarà utile un giorno?"*. La domanda giusta è: **"questa soluzione è utile adesso, per il problema che ho adesso?"**
 
@@ -47,9 +48,9 @@ Scala cosa, esattamente?
 
 Scalare un problema che non esiste è uno dei modi più efficaci per crearne uno nuovo. Un database relazionale con qualche indice fatto bene avrebbe risolto tutto in un pomeriggio. Invece si passano settimane a configurare strumenti progettati per petabyte di dati, mentre il problema reale — quello che il cliente aspetta — rimane in coda.
 
-Nel linguaggio Pokémon: è come insegnare *Idro Pompa* a un Magikarp al livello 3. La mossa esiste, è potente, ha senso — ma non per quel Pokémon, non in quel momento. Prima devi aspettare il livello 20. Prima devi guadagnarti Gyarados.
+Nel linguaggio Pokémon: è come insegnare *Idropompa* a un Magikarp al livello 3. La mossa esiste, è potente, ha senso — ma non per quel Pokémon, non in quel momento. Prima devi aspettare il livello 20. Prima devi guadagnarti Gyarados.
 
-❌ **La trappola**: "Quando cresceremo, saremo già pronti."
+❌ **La trappola**: "Quando cresceremo, saremo già pronti."  
 ✅ **La realtà**: Quando crescerete, saprete cosa costruire. Adesso non lo sapete ancora.
 
 ### 2. Microservizi per un team da uno
@@ -64,7 +65,7 @@ Il risultato? Un monolite distribuito. Ovvero: tutti gli svantaggi dei microserv
 
 È l'equivalente di insegnare al tuo Pokémon solo mosse di tipo diverso dal suo, sperando che "copra più terreno." In teoria ha senso. In pratica, non sarà mai super efficace su nulla, e perderà tutti i bonus del STAB — il Same Type Attack Bonus che ottieni quando usi una mossa dello stesso tipo del tuo Pokémon.
 
-❌ **La trappola**: "È best practice."
+❌ **La trappola**: "È best practice."  
 ✅ **La realtà**: È best practice *in un contesto specifico*. Il tuo contesto è diverso.
 
 ### 3. L'AI che risolve problemi che non hai
@@ -73,7 +74,7 @@ Vale la pena citarla: introdurre un layer di AI generativa in un workflow dove i
 
 L'AI è uno strumento potente. Come tutti gli strumenti potenti, amplifica. Se il problema è reale, amplifica la soluzione. Se il problema non è reale, amplifica il caos.
 
-Anche in Pokémon, una MN — le Mosse Nascoste — può essere usata solo in certi punti della mappa. *Surf* ti serve per attraversare l'oceano. Usarla in un campo erboso non ti porta da nessuna parte. Non è un difetto della mossa. È un difetto del contesto in cui la stai usando.
+Anche in Pokémon, una MN — una Macchina Nascosta — può essere usata solo in certi punti della mappa. *Surf* ti serve per attraversare l'oceano. Usarla in un campo erboso non ti porta da nessuna parte. Non è un difetto della mossa. È un difetto del contesto in cui la stai usando.
 
 ---
 
@@ -101,7 +102,7 @@ La fuga dice: *"Costruiamo la cosa più complessa, così non dobbiamo affrontare
 
 Ho visto entrambe. La seconda si riconosce da un segnale infallibile: nessuno sa esattamente qual è il problema che si sta risolvendo, ma tutti concordano che la soluzione è molto elegante.
 
-Il Professor Oak non ti dava la Pokédex già piena di Pokémon catturati. Non ti consegnava la Master Ball al primo giorno di gioco. Ti diceva: *"Vai, esplora, impara."* Ogni strumento al momento giusto, ogni badge conquistato sul campo — non regalato.
+Il Professor Oak non ti dava il Pokédex già pieno di Pokémon catturati. Non ti consegnava la Master Ball al primo giorno di gioco. Ti diceva: *"Vai, esplora, impara."* Ogni strumento al momento giusto, ogni badge conquistato sul campo — non regalato.
 
 ---
 
@@ -124,11 +125,3 @@ Le tecnologie che adotti prematuramente non sono sbagliate in assoluto. Spesso s
 E nel frattempo, il problema che hai — quello vero, quello che i tuoi utenti aspettano che tu risolva — rimane lì, ad aspettare.
 
 **Non è il momento di usare la bici. Vai a piedi. Ci vuole meno.**
-
----
-
-*A te la palla: hai vissuto situazioni in cui una soluzione "troppo avanti" ha bloccato invece di accelerare? Raccontamelo.*
-
----
-
-*P.S. Questo articolo è stato scritto con il supporto di AI. Il Professor Oak e il mio Gameboy Color, invece, sono tutti miei.*


### PR DESCRIPTION
## What's in this PR

Adds a new bilingual blog post inspired by Professor Oak's famous line from Pokémon.

**Italian:** `src/pages/blog/tempo-e-luogo-per-ogni-cosa.md`
**English:** `src/pages/blog/en/theres-a-time-and-a-place.md`

## Post summary

The post argues that adopting tomorrow's solution for today's problem — whether in architecture, leadership, or AI — is one of the most destructive things a team can do. The bicycle works, but not inside a building.

Pokémon references woven throughout:
- Elite Four / level 5 Pikachu (wrong timing)
- Magikarp learning Hydro Pump at level 3 (earn your Gyarados first)
- STAB bonuses / type mismatches (microservices without the right context)
- HM Surf in a grassy field (AI solving problems you don't have)
- Professor Oak not handing you the Master Ball on day one

## Frontmatter
- `date: 2026-04-17`
- `lang: it` / `lang: en`
- `hasTranslation: true` (both files point to each other)
- `AISupport: mid`

## Checklist
- [x] Italian version
- [x] English version
- [x] Frontmatter matches conventions from existing posts
- [x] Layout paths correct (`../../layouts/...` for IT, `../../../layouts/...` for EN)
